### PR TITLE
Fix blogs link in "/blogs"

### DIFF
--- a/src/pages/blogs.js
+++ b/src/pages/blogs.js
@@ -30,7 +30,7 @@ export default class Blogs extends Component {
                 return (
                   <li key={index} className="item">
                     <div className="inner">
-                      <Link className="link" to={item.node.slug} />
+                      <Link className="link" to={`/${item.node.slug}`} />
                       {item.node.featureImage ? (
                         <Img
                           fixed={item.node.featureImage.fluid}


### PR DESCRIPTION
When you click in "More Blogs" — going to `/blogs` — the blog links are broken. This fixes it by prepending a `/` to it